### PR TITLE
fix: Readme Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!(
         "{}{}",
         prompt,
-        client.complete(prompt.as_str()).await?
+        client.complete_prompt(prompt.as_str()).await?
     );
     Ok(())
 }


### PR DESCRIPTION
# What
corrected `complete()` to `complete_prompt()`

# Why
Incorrect method name:

```
error[E0599]: no method named `complete` found for struct `Client` in the current scope
  --> src/main.rs:11:16
   |
11 |         client.complete(prompt.as_str()).await?
   |                ^^^^^^^^ help: there is a method with a similar name: `complete_prompt`
```