### PR TITLE
Update tokio to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rustdocflags = ["--all-features"]
 [features]
 default = ["sync", "async"]
 sync = ["ureq"]
-async = ["surf/hyper-client"]
+async = ["surf/h1-client"]
 
 [dependencies]
 thiserror = "^1.0.22"
@@ -33,6 +33,6 @@ surf = { version = "^2.1.0", optional=true, default-features=false}
 [dev-dependencies]
 mockito = "0.28.0"
 maplit = "1.0.2"
-tokio = { version = "^0.2.5", features = ["full"]}
+tokio = { version = "1", features = ["full"]}
 env_logger = "0.8.2"
 serde_json = "^1.0"


### PR DESCRIPTION
The Surf `hyper-client` feature requires tokio 0.2.x, but 1.0 has been released
for a long time. This changes to use the surf `h1-feature` instead, which is
built on top of tokio 1.0.
